### PR TITLE
Fix/failing validator ci check

### DIFF
--- a/.github/workflows/schema-validator.yaml
+++ b/.github/workflows/schema-validator.yaml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Install/Update Packages
+        run: sudo apt-get update && sudo apt-get install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
       - name: Validate OB OpenAPI
         uses: swaggerexpert/swagger-editor-validate@master
         with:

--- a/.github/workflows/schema-validator.yaml
+++ b/.github/workflows/schema-validator.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Validate OB OpenAPI
-        uses: char0n/swagger-editor-validate@master
+        uses: swaggerexpert/swagger-editor-validate@master
         with:
           definition-file: Master-OB-OpenAPI.json
 

--- a/.github/workflows/schema-validator.yaml
+++ b/.github/workflows/schema-validator.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install/Update Packages
-        run: sudo apt-get update && sudo apt-get install -y libnss3 libgdk-pixbuf2.0 libgtk-3-dev libxss-dev libasound2
+        run: sudo apt-get update && sudo apt-get install -y libnss3 libgdk-pixbuf2.0 libgtk-3-dev libxss-dev libasound2t64
       - name: Validate OB OpenAPI
         uses: swaggerexpert/swagger-editor-validate@master
         with:

--- a/.github/workflows/schema-validator.yaml
+++ b/.github/workflows/schema-validator.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install/Update Packages
-        run: sudo apt-get update && sudo apt-get install -y libnss3-dev libgdk-pixbuf2.0-dev libgtk-3-dev libxss-dev libasound2
+        run: sudo apt-get update && sudo apt-get install -y libnss3 libgdk-pixbuf2.0 libgtk-3-dev libxss-dev libasound2
       - name: Validate OB OpenAPI
         uses: swaggerexpert/swagger-editor-validate@master
         with:


### PR DESCRIPTION
fixes issue with `Failure to launch browser process!` error in Validate OB OpenAPI CI check (e.g. https://github.com/Open-Orange-Button/Orange-Button-Taxonomy/actions/runs/13017938252/job/36311597046) via workaround (manually installing and/or updating Puppeteer-related packages) in preceding step